### PR TITLE
Fix wording on register page link

### DIFF
--- a/frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterPage from './RegisterPage';
+
+// mock auth store used by the component
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({ register: vi.fn(), isLoading: false })
+}));
+
+describe('RegisterPage', () => {
+  it('renders sign in link with correct text', () => {
+    const html = renderToString(
+      <MemoryRouter>
+        <RegisterPage />
+      </MemoryRouter>
+    );
+    expect(html).toContain('sign in to an existing account');
+  });
+});

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -49,7 +49,7 @@ export default function RegisterPage() {
               to="/login"
               className="font-medium text-primary-600 hover:text-primary-500"
             >
-              sign in to existing account
+              sign in to an existing account
             </Link>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- add missing article to sign-in link text
- add RegisterPage test to verify link rendering

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find a configuration file)*
- `npm run build:frontend` *(fails: TypeScript errors in unrelated components)*
- `npx vitest run src/pages/RegisterPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac83eeb36c8332b93da66201a9661d